### PR TITLE
Importing composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,7 +123,8 @@ composer.phar
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-# composer.lock
+app/composer.lock
+
 ### Dropbox template
 # Dropbox settings and caches
 .dropbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
  && docker-php-ext-install pdo pdo_mysql \
  && a2enmod rewrite \
  && curl -sS https://getcomposer.org/installer \
-  | php -- --install-dir=/usr/local/bin --filename=composer
+  | php -- --install-dir=/usr/local/bin --filename=composer \
+ && /usr/local/bin/composer install
 
 WORKDIR /var/www/html

--- a/app/composer.json
+++ b/app/composer.json
@@ -1,0 +1,20 @@
+{
+  "name": "vespercore02/mymvc",
+  "description": "VesperCore's First MVC",
+  "minimum-stability": "stable",
+  "license": "proprietary",
+  "authors": [
+    {
+      "name": "Wil Lem",
+      "email": "email@example.com"
+    },
+    {
+      "name": "Matt Wiseman",
+      "email": "trollboy@shoggoth.net"
+    }
+  ],
+  "require": {
+    "vlucas/phpdotenv": "1.0.6",
+    "phpunit/phpunit": "8.1.3"
+  }
+}

--- a/app/index.php
+++ b/app/index.php
@@ -1,5 +1,7 @@
 <?php
 
+require __DIR__ . '/vendor/autoload.php';
+
 require 'router.php';
 require 'Resources/config/config.php';
 require 'Controllers/controller.php';

--- a/app/router.php
+++ b/app/router.php
@@ -41,4 +41,3 @@ class Router
 
 }
 
-?>


### PR DESCRIPTION
This small PR introduces composer into the source code.  This will allow us to easily import helper libraries, as well as allow me to start showing you how namespaces work, and how the magical psr* autoloaders work.

I also added a line to the dockerfile to run composer install on build.  After this code is merged in, you can run `docker-compose build` and it will rebuild the application with those new libraries.  

the `app/vendors` directory is added to the `.gitignore` file.  This is because these 3rd party libraries aren't _your_ code and you shouldn't worry about them.  We specify the versions of the libraries we want in the `composer.json` file and just automagically include them in our vendor directory.